### PR TITLE
feat: Update build process to create Windows installer using Inno Setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Windows Executable
+name: Build Windows Installer
 permissions:
   contents: write
 
@@ -26,6 +26,9 @@ jobs:
           pip install -r requirements.txt
           pip install pyinstaller
 
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
       - name: Write VERSION and RELEASE_DATE files from release tag
         if: github.event_name == 'release'
         run: |
@@ -38,8 +41,46 @@ jobs:
           Write-Host "RELEASE_DATE set to $releaseDate"
 
       - name: Build executable with PyInstaller
+        shell: pwsh
         run: |
-          pyinstaller --noconfirm --clean --onefile --windowed --name "US-DICOMizer" --icon=icon.ico --upx-exclude "*.pyd" --upx-exclude "*.dll" --exclude-module torch --exclude-module torchvision --exclude-module torchaudio --add-data "icon.ico;." --add-data "Logo_Blue_Green_small.png;." --add-data "US-DICOMizer_manual.pdf;." --add-data "VERSION;." --add-data "RELEASE_DATE;." --hidden-import pydicom --hidden-import pydicom.pixels --hidden-import pydicom.pixels.utils --hidden-import pydicom.pixels.decoders --hidden-import pydicom.pixels.decoders.gdcm --hidden-import pydicom.pixels.decoders.pillow --hidden-import pydicom.pixels.decoders.pylibjpeg --hidden-import pydicom.pixels.encoders --hidden-import pydicom.pixels.encoders.gdcm --hidden-import pydicom.pixels.encoders.pylibjpeg --hidden-import pydicom.encaps --hidden-import pydicom.uid --hidden-import pydicom.dataelem --hidden-import pylibjpeg --hidden-import pylibjpeg.utils --hidden-import libjpeg --hidden-import tkhtmlview --hidden-import tkhtmlview.html_parser --hidden-import tkhtmlview.utils US-DICOMizer.py
+          $repo = (Get-Location).Path
+          pyinstaller --noconfirm --clean --onefile --windowed `
+            --specpath build/pyinstaller-specs `
+            --name "US-DICOMizer" `
+            --icon="$repo\icon.ico" `
+            --upx-exclude "*.pyd" `
+            --upx-exclude "*.dll" `
+            --exclude-module torch `
+            --exclude-module torchvision `
+            --exclude-module torchaudio `
+            --add-data "$repo\icon.ico;." `
+            --add-data "$repo\Logo_Blue_Green_small.png;." `
+            --add-data "$repo\US-DICOMizer_manual.pdf;." `
+            --add-data "$repo\VERSION;." `
+            --add-data "$repo\RELEASE_DATE;." `
+            --hidden-import pydicom `
+            --hidden-import pydicom.pixels `
+            --hidden-import pydicom.pixels.utils `
+            --hidden-import pydicom.pixels.decoders `
+            --hidden-import pydicom.pixels.decoders.gdcm `
+            --hidden-import pydicom.pixels.decoders.pillow `
+            --hidden-import pydicom.pixels.decoders.pylibjpeg `
+            --hidden-import pydicom.pixels.encoders `
+            --hidden-import pydicom.pixels.encoders.gdcm `
+            --hidden-import pydicom.pixels.encoders.pylibjpeg `
+            --hidden-import pydicom.encaps `
+            --hidden-import pydicom.uid `
+            --hidden-import pydicom.dataelem `
+            --hidden-import pylibjpeg `
+            --hidden-import pylibjpeg.utils `
+            --hidden-import libjpeg `
+            --hidden-import tkhtmlview `
+            --hidden-import tkhtmlview.html_parser `
+            --hidden-import tkhtmlview.utils `
+            US-DICOMizer.py
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
       - name: Verify bundled payload and size
         shell: pwsh
@@ -69,22 +110,42 @@ jobs:
             throw "Unexpected torch-family modules found in bundled payload"
           }
 
-      - name: Package Release
+      - name: Build updater executable with PyInstaller
         shell: pwsh
         run: |
-          $tag = if ("${{ github.event_name }}" -eq "release") { "${{ github.event.release.tag_name }}" } else { "${{ github.ref_name }}" }
-          Compress-Archive -Path dist/US-DICOMizer.exe -DestinationPath "US-DICOMizer-Windows-$tag.zip"
+          $repo = (Get-Location).Path
+          pyinstaller --noconfirm --clean --onefile --windowed --specpath build/pyinstaller-specs --name "US-DICOMizer-Updater" --icon="$repo\icon.ico" us_dicomizer_updater.py
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if (-not (Test-Path "dist/US-DICOMizer-Updater.exe")) {
+            throw "Updater executable was not produced"
+          }
+
+      - name: Compile setup installer
+        shell: pwsh
+        run: |
+          $version = (Get-Content -Path "VERSION" -Raw).Trim()
+          $iscc = Join-Path ${env:ProgramFiles(x86)} "Inno Setup 6\ISCC.exe"
+          & $iscc "/DAppVersion=$version" "installer\US-DICOMizer.iss"
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $setup = "dist/installer/US-DICOMizer-Setup-v$version.exe"
+          if (-not (Test-Path $setup)) {
+            throw "Setup installer was not produced: $setup"
+          }
 
       - name: Upload to Release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: US-DICOMizer-Windows-${{ github.event.release.tag_name }}.zip
+          files: dist/installer/US-DICOMizer-Setup-${{ github.event.release.tag_name }}.exe
 
       - name: Upload artifact (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: US-DICOMizer-Windows
-          path: ./US-DICOMizer-Windows-${{ github.ref_name }}.zip
+          name: US-DICOMizer-Setup
+          path: ./dist/installer/US-DICOMizer-Setup-v*.exe

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ These functionalities aim to address the unique requirements of ultrasound imagi
 
 ![US-DICOMizer main view](images/app_main_window.png)
 
+## Installation and updates
+
+Windows releases are distributed as a single setup executable named `US-DICOMizer-Setup-vX.Y.exe`.
+The installer installs US-DICOMizer per user under `%LOCALAPPDATA%\Programs\US-DICOMizer`, adds a Start Menu shortcut, and keeps settings/output data in `%USERPROFILE%\.anonymizer`.
+
+Installed builds check public GitHub releases for updates on startup and through **Menu -> Check for updates**. When a newer setup release is available, the app downloads that one setup file, closes, runs the bundled updater, installs the update silently, and relaunches.
+
 ## Changelog
 
 ### Changes in version 5.2

--- a/US-DICOMizer.py
+++ b/US-DICOMizer.py
@@ -10,8 +10,6 @@ import webbrowser
 import shutil
 import subprocess
 from threading import Thread
-import urllib.request
-import urllib.error
 #import threading
 import sys
 import ast
@@ -62,6 +60,19 @@ from settings_io_utils import (
     write_config_atomic,
     write_text_atomic,
 )
+from update_service import (
+    UPDATER_EXE_NAME,
+    build_updater_command,
+    can_apply_installer_update,
+    clear_old_downloads,
+    download_file,
+    fetch_latest_release,
+    get_installed_updater_path,
+    get_installer_download_path,
+    get_updates_dir,
+    is_newer_version,
+    select_setup_asset,
+)
 
 
 def resource_path(relative_path):
@@ -90,54 +101,188 @@ def _read_release_date():
         return "Unknown"
 
 
-GITHUB_RELEASES_API = "https://api.github.com/repos/thrombusplus/US-DICOMizer/releases/latest"
-
-
-def _parse_version(v):
-    """Parse a version string like '4.16' into a tuple of ints for comparison."""
+def _log_update_message(message, level="info"):
     try:
-        return tuple(int(x) for x in v.split("."))
-    except (ValueError, AttributeError):
-        return (0,)
+        console_message(message, level=level)
+    except Exception:
+        try:
+            logger.log(getattr(logging, level.upper(), logging.INFO), message)
+        except Exception:
+            pass
 
 
-def _show_update_dialog(latest_tag, release_url):
-    """Show a dialog (on the main thread) informing the user of a new release."""
+def _can_apply_installer_update():
+    updater_path = get_installed_updater_path(sys.executable)
+    return can_apply_installer_update(
+        is_frozen=bool(getattr(sys, "frozen", False)),
+        app_executable_path=sys.executable,
+        updater_path=updater_path,
+    )
+
+
+def _show_no_update_dialog():
+    messagebox.showinfo("Check for updates", f"US-DICOMizer {version} is up to date.")
+
+
+def _show_update_error(message):
+    messagebox.showerror("Check for updates", message)
+
+
+def _open_release_page(release_url):
+    webbrowser.open(release_url)
+
+
+def _show_manual_update_dialog(latest_tag, release_url):
     if messagebox.askyesno(
         "Update Available",
-        f"A new version ({latest_tag}) is available.\n\nWould you like to open the download page?",
+        (
+            f"A new version ({latest_tag}) is available.\n\n"
+            "Automatic install is available only from the installed app. "
+            "Would you like to open the download page?"
+        ),
     ):
-        webbrowser.open(release_url)
+        _open_release_page(release_url)
 
 
-def check_for_updates():
-    """Background thread: compare latest GitHub release tag against the running version."""
+def _prompt_update_install(release, asset):
+    latest_tag = release.get("tag_name", "")
+    release_url = release.get("html_url", "")
+    if not _can_apply_installer_update():
+        _show_manual_update_dialog(latest_tag, release_url)
+        return
+
+    if messagebox.askyesno(
+        "Update Available",
+        (
+            f"A new version ({latest_tag}) is available.\n\n"
+            "Download and install it now? US-DICOMizer will close and restart "
+            "after setup finishes."
+        ),
+    ):
+        _download_and_install_update(release, asset)
+
+
+def _download_and_install_update(release, asset):
+    latest_tag = release.get("tag_name", "")
+    dialog = tk.Toplevel(root)
+    dialog.title("Downloading update")
+    dialog.geometry("420x130")
+    dialog.resizable(False, False)
+    dialog.transient(root)
+
+    status_var = tk.StringVar(value=f"Downloading {latest_tag} setup...")
+    status_label = ttk.Label(dialog, textvariable=status_var, wraplength=380)
+    status_label.pack(fill="x", padx=16, pady=(16, 8))
+
+    progress_var = tk.DoubleVar(value=0)
+    progress_bar = ttk.Progressbar(dialog, mode="indeterminate", variable=progress_var, maximum=100)
+    progress_bar.pack(fill="x", padx=16, pady=(0, 12))
+    progress_bar.start(10)
+
+    def update_progress(downloaded, total):
+        def apply_progress():
+            if not dialog.winfo_exists():
+                return
+            if total:
+                progress_bar.stop()
+                progress_bar.configure(mode="determinate")
+                percent = min(100, int((downloaded / total) * 100))
+                progress_var.set(percent)
+                status_var.set(f"Downloading {latest_tag} setup... {percent}%")
+            else:
+                status_var.set(f"Downloading {latest_tag} setup... {downloaded // 1024} KB")
+
+        root.after(0, apply_progress)
+
+    def finish(installer_path):
+        if dialog.winfo_exists():
+            progress_bar.stop()
+            status_var.set("Starting installer...")
+            dialog.update_idletasks()
+        _launch_update_installer(installer_path, dialog)
+
+    def fail(exc):
+        if dialog.winfo_exists():
+            progress_bar.stop()
+            dialog.destroy()
+        messagebox.showerror("Update failed", f"Failed to download the update:\n{exc}")
+        release_url = release.get("html_url", "")
+        if release_url and messagebox.askyesno(
+            "Open download page?",
+            "Would you like to open the release page instead?",
+        ):
+            _open_release_page(release_url)
+
+    def worker():
+        try:
+            installer_path = get_installer_download_path(app_directory, asset["name"])
+            clear_old_downloads(get_updates_dir(app_directory), installer_path)
+            download_file(asset["browser_download_url"], installer_path, progress_callback=update_progress)
+            root.after(0, lambda: finish(installer_path))
+        except Exception as exc:
+            root.after(0, lambda error=exc: fail(error))
+
+    Thread(target=worker, daemon=True).start()
+
+
+def _launch_update_installer(installer_path, dialog=None):
+    updates_dir = get_updates_dir(app_directory)
+    source_updater_path = get_installed_updater_path(sys.executable)
+    runtime_updater_path = os.path.join(updates_dir, UPDATER_EXE_NAME)
+    log_path = os.path.join(updates_dir, "update.log")
+
     try:
-        req = urllib.request.Request(
-            GITHUB_RELEASES_API,
-            headers={"User-Agent": "US-DICOMizer"},
+        os.makedirs(updates_dir, exist_ok=True)
+        shutil.copy2(source_updater_path, runtime_updater_path)
+        command = build_updater_command(
+            updater_path=runtime_updater_path,
+            installer_path=installer_path,
+            app_executable_path=sys.executable,
+            app_pid=os.getpid(),
+            log_path=log_path,
         )
-        with urllib.request.urlopen(req, timeout=5) as response:
-            data = json.loads(response.read().decode())
+        subprocess.Popen(command, close_fds=True)
+    except Exception as exc:
+        if dialog is not None and dialog.winfo_exists():
+            dialog.destroy()
+        messagebox.showerror("Update failed", f"Failed to start the updater:\n{exc}")
+        return
 
-        latest_tag = data.get("tag_name", "")          # e.g. "v4.17"
-        release_url = data.get("html_url", GITHUB_RELEASES_API)
+    if dialog is not None and dialog.winfo_exists():
+        dialog.destroy()
+    root.after(200, lambda: (root.quit(), root.destroy()))
 
-        if not latest_tag:
+
+def check_for_updates(manual=False):
+    """Background thread: compare latest GitHub setup release against the running version."""
+    try:
+        release = fetch_latest_release()
+        latest_tag = release.get("tag_name", "")
+        if not latest_tag or not is_newer_version(version, latest_tag):
+            if manual:
+                root.after(0, _show_no_update_dialog)
             return
 
-        latest_clean = latest_tag.lstrip("v")
-        current_tuple = _parse_version(version)
-        latest_tuple  = _parse_version(latest_clean)
+        asset = select_setup_asset(release)
+        if not asset:
+            if manual:
+                root.after(
+                    0,
+                    lambda: _show_update_error(
+                        f"A newer release ({latest_tag}) exists, but it does not include a setup installer."
+                    ),
+                )
+            return
 
-        if latest_tuple > current_tuple:
-            # Schedule the dialog on the main tkinter thread
-            tag = latest_tag
-            url = release_url
-            root.after(0, lambda: _show_update_dialog(tag, url))
-    except Exception:
-        # Network/parse errors are silently ignored
-        pass
+        root.after(0, lambda: _prompt_update_install(release, asset))
+    except Exception as exc:
+        _log_update_message(f"Update check failed: {exc}", level="debug")
+        if manual:
+            root.after(0, lambda error=exc: _show_update_error(f"Failed to check for updates:\n{error}"))
+
+
+def start_update_check(manual=False):
+    Thread(target=lambda: check_for_updates(manual=manual), daemon=True).start()
 
 import re
 import logging
@@ -4011,6 +4156,7 @@ def menubar():
     root_menu.add_cascade(label="Menu", menu=main_menu)
     main_menu.add_command(label="Settings", command=settings)
     main_menu.add_command(label="App manual", command=open_manual)
+    main_menu.add_command(label="Check for updates", command=lambda: start_update_check(manual=True))
     main_menu.add_command(label="About", command=about)
     main_menu.add_separator()
     main_menu.add_command(label="Exit", command=root.quit)
@@ -4333,5 +4479,5 @@ root.bind("<Prior>",lambda event: move_up())
 root.bind("<Next>",lambda event: move_down())
 
 logger.info('loaded all functions successfully')
-Thread(target=check_for_updates, daemon=True).start()
+start_update_check(manual=False)
 root.mainloop()

--- a/build.ps1
+++ b/build.ps1
@@ -7,6 +7,29 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 
+function Find-InnoSetupCompiler {
+    $candidates = @()
+    if (${env:ProgramFiles(x86)}) {
+        $candidates += Join-Path ${env:ProgramFiles(x86)} "Inno Setup 6\ISCC.exe"
+    }
+    if ($env:ProgramFiles) {
+        $candidates += Join-Path $env:ProgramFiles "Inno Setup 6\ISCC.exe"
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            return $candidate
+        }
+    }
+
+    $command = Get-Command "iscc.exe" -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    throw "Inno Setup compiler (ISCC.exe) was not found. Install Inno Setup 6 and rerun build.ps1."
+}
+
 Write-Host "==> Installing / updating dependencies..." -ForegroundColor Cyan
 python -m pip install --upgrade pip
 pip install -r requirements.txt
@@ -14,21 +37,29 @@ pip install pyinstaller
 
 Write-Host "==> Building executable with PyInstaller..." -ForegroundColor Cyan
 Stop-Process -Name "US-DICOMizer" -ErrorAction SilentlyContinue
+Stop-Process -Name "US-DICOMizer-Updater" -ErrorAction SilentlyContinue
+
+$IconPath = Join-Path $ScriptDir "icon.ico"
+$LogoPath = Join-Path $ScriptDir "Logo_Blue_Green_small.png"
+$ManualPath = Join-Path $ScriptDir "US-DICOMizer_manual.pdf"
+$VersionPath = Join-Path $ScriptDir "VERSION"
+$ReleaseDatePath = Join-Path $ScriptDir "RELEASE_DATE"
 
 pyinstaller --noconfirm --onefile --windowed `
     --clean `
+    --specpath "build\pyinstaller-specs" `
     --name "US-DICOMizer" `
-    --icon=icon.ico `
+    --icon="$IconPath" `
     --upx-exclude "*.pyd" `
     --upx-exclude "*.dll" `
     --exclude-module torch `
     --exclude-module torchvision `
     --exclude-module torchaudio `
-    --add-data "icon.ico;." `
-    --add-data "Logo_Blue_Green_small.png;." `
-    --add-data "US-DICOMizer_manual.pdf;." `
-    --add-data "VERSION;." `
-    --add-data "RELEASE_DATE;." `
+    --add-data "$IconPath;." `
+    --add-data "$LogoPath;." `
+    --add-data "$ManualPath;." `
+    --add-data "$VersionPath;." `
+    --add-data "$ReleaseDatePath;." `
     --hidden-import pydicom `
     --hidden-import pydicom.pixels `
     --hidden-import pydicom.pixels.utils `
@@ -49,6 +80,11 @@ pyinstaller --noconfirm --onefile --windowed `
     --hidden-import tkhtmlview.html_parser `
     --hidden-import tkhtmlview.utils `
     US-DICOMizer.py
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "PyInstaller failed with exit code $LASTEXITCODE" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
 
 Write-Host "==> Verifying bundled payload and size..." -ForegroundColor Cyan
 $Exe = Get-Item "dist\US-DICOMizer.exe"
@@ -79,17 +115,42 @@ if (Select-String -Path $ArchiveList -Pattern "torch\\|torchvision\\|torchaudio\
     exit 1
 }
 
+Write-Host "==> Building updater executable with PyInstaller..." -ForegroundColor Cyan
+pyinstaller --noconfirm --onefile --windowed `
+    --clean `
+    --specpath "build\pyinstaller-specs" `
+    --name "US-DICOMizer-Updater" `
+    --icon="$IconPath" `
+    us_dicomizer_updater.py
+
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "PyInstaller failed with exit code $LASTEXITCODE" -ForegroundColor Red
+    Write-Host "Updater PyInstaller failed with exit code $LASTEXITCODE" -ForegroundColor Red
     exit $LASTEXITCODE
 }
 
-Write-Host "==> Packaging..." -ForegroundColor Cyan
+if (-not (Test-Path "dist\US-DICOMizer-Updater.exe")) {
+    Write-Host "Updater executable was not produced." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "==> Compiling setup installer..." -ForegroundColor Cyan
 $Version = (Get-Content -Path "VERSION" -Raw).Trim()
-$ZipName = "US-DICOMizer-Windows-v$Version.zip"
-Compress-Archive -Force -Path "dist\US-DICOMizer.exe" -DestinationPath $ZipName
+$Iscc = Find-InnoSetupCompiler
+& $Iscc "/DAppVersion=$Version" "installer\US-DICOMizer.iss"
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Inno Setup failed with exit code $LASTEXITCODE" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+$SetupName = "dist\installer\US-DICOMizer-Setup-v$Version.exe"
+if (-not (Test-Path $SetupName)) {
+    Write-Host "Setup installer was not produced: $SetupName" -ForegroundColor Red
+    exit 1
+}
 
 Write-Host ""
 Write-Host "Build complete!" -ForegroundColor Green
 Write-Host "  Executable : dist\US-DICOMizer.exe"
-Write-Host "  Archive    : $ZipName"
+Write-Host "  Updater    : dist\US-DICOMizer-Updater.exe"
+Write-Host "  Setup      : $SetupName"

--- a/installer/US-DICOMizer.iss
+++ b/installer/US-DICOMizer.iss
@@ -1,0 +1,44 @@
+#define MyAppName "US-DICOMizer"
+#define MyAppPublisher "ThrombUS+"
+#define MyAppURL "https://github.com/thrombusplus/US-DICOMizer"
+#ifndef AppVersion
+#define AppVersion "0.0"
+#endif
+#ifndef SourceDir
+#define SourceDir "..\dist"
+#endif
+
+[Setup]
+AppId={{8D78B5B4-5B80-4D4F-9A54-3C13728EAFB0}
+AppName={#MyAppName}
+AppVersion={#AppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={localappdata}\Programs\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableDirPage=yes
+DisableProgramGroupPage=yes
+UsePreviousAppDir=no
+UninstallDisplayIcon={app}\US-DICOMizer.exe
+PrivilegesRequired=lowest
+OutputDir=..\dist\installer
+OutputBaseFilename=US-DICOMizer-Setup-v{#AppVersion}
+SetupIconFile=..\icon.ico
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+
+[Files]
+Source: "{#SourceDir}\US-DICOMizer.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\US-DICOMizer-Updater.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\icon.ico"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\Logo_Blue_Green_small.png"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\US-DICOMizer_manual.pdf"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\VERSION"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\RELEASE_DATE"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\US-DICOMizer.exe"; WorkingDir: "{app}"
+

--- a/tests/test_anonymized_filename_utils.py
+++ b/tests/test_anonymized_filename_utils.py
@@ -141,7 +141,7 @@ class AnonymizedFilenameUtilsTests(unittest.TestCase):
     def test_tag_value_to_display_label_uses_human_readable_description(self):
         self.assertEqual(
             tag_value_to_display_label("CFVr-R"),
-            "Common Femoral Vein R-shot (Right)",
+            "Common Femoral Vein Random Image(Right)",
         )
 
 

--- a/tests/test_update_service.py
+++ b/tests/test_update_service.py
@@ -1,0 +1,123 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from update_service import (
+    build_updater_command,
+    can_apply_installer_update,
+    get_installer_download_path,
+    is_newer_version,
+    select_setup_asset,
+)
+
+
+class UpdateServiceTests(unittest.TestCase):
+    def test_is_newer_version_compares_numeric_release_tags(self):
+        self.assertTrue(is_newer_version("5.2", "v5.10"))
+        self.assertFalse(is_newer_version("5.10", "v5.2"))
+        self.assertFalse(is_newer_version("5.2", "v5.2"))
+
+    def test_select_setup_asset_uses_single_installer_exe(self):
+        release = {
+            "prerelease": False,
+            "tag_name": "v5.3",
+            "assets": [
+                {
+                    "name": "US-DICOMizer-Windows-v5.3.zip",
+                    "browser_download_url": "https://example.invalid/zip",
+                },
+                {
+                    "name": "US-DICOMizer-Setup-v5.3.exe",
+                    "browser_download_url": "https://example.invalid/setup",
+                },
+                {
+                    "name": "US-DICOMizer-Updater.exe",
+                    "browser_download_url": "https://example.invalid/updater",
+                },
+            ],
+        }
+
+        asset = select_setup_asset(release)
+
+        self.assertEqual(asset["name"], "US-DICOMizer-Setup-v5.3.exe")
+        self.assertEqual(asset["browser_download_url"], "https://example.invalid/setup")
+
+    def test_select_setup_asset_ignores_prerelease(self):
+        release = {
+            "prerelease": True,
+            "tag_name": "v5.3",
+            "assets": [
+                {
+                    "name": "US-DICOMizer-Setup-v5.3.exe",
+                    "browser_download_url": "https://example.invalid/setup",
+                }
+            ],
+        }
+
+        self.assertIsNone(select_setup_asset(release))
+
+    def test_get_installer_download_path_stays_inside_updates_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = get_installer_download_path(
+                tmp_dir,
+                r"..\US-DICOMizer-Setup-v5.3.exe",
+            )
+
+            expected = Path(tmp_dir) / "updates" / "US-DICOMizer-Setup-v5.3.exe"
+            self.assertEqual(Path(path), expected)
+
+    def test_build_updater_command_passes_installer_app_and_pid(self):
+        command = build_updater_command(
+            updater_path=r"C:\Users\me\AppData\Local\Programs\US-DICOMizer\US-DICOMizer-Updater.exe",
+            installer_path=r"C:\Users\me\.anonymizer\updates\US-DICOMizer-Setup-v5.3.exe",
+            app_executable_path=r"C:\Users\me\AppData\Local\Programs\US-DICOMizer\US-DICOMizer.exe",
+            app_pid=1234,
+        )
+
+        self.assertEqual(command[0], r"C:\Users\me\AppData\Local\Programs\US-DICOMizer\US-DICOMizer-Updater.exe")
+        self.assertIn("--installer", command)
+        self.assertIn(r"C:\Users\me\.anonymizer\updates\US-DICOMizer-Setup-v5.3.exe", command)
+        self.assertIn("--app-exe", command)
+        self.assertIn(r"C:\Users\me\AppData\Local\Programs\US-DICOMizer\US-DICOMizer.exe", command)
+        self.assertIn("--app-pid", command)
+        self.assertIn("1234", command)
+
+    def test_can_apply_installer_update_requires_frozen_installed_app_with_updater(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_app_data = Path(tmp_dir) / "LocalAppData"
+            install_dir = local_app_data / "Programs" / "US-DICOMizer"
+            install_dir.mkdir(parents=True)
+            app_exe = install_dir / "US-DICOMizer.exe"
+            updater_exe = install_dir / "US-DICOMizer-Updater.exe"
+            app_exe.write_text("app", encoding="utf-8")
+            updater_exe.write_text("updater", encoding="utf-8")
+
+            self.assertTrue(
+                can_apply_installer_update(
+                    is_frozen=True,
+                    app_executable_path=str(app_exe),
+                    updater_path=str(updater_exe),
+                    local_app_data=str(local_app_data),
+                )
+            )
+            self.assertFalse(
+                can_apply_installer_update(
+                    is_frozen=False,
+                    app_executable_path=str(app_exe),
+                    updater_path=str(updater_exe),
+                    local_app_data=str(local_app_data),
+                )
+            )
+            self.assertFalse(
+                can_apply_installer_update(
+                    is_frozen=True,
+                    app_executable_path=os.path.join(tmp_dir, "US-DICOMizer.exe"),
+                    updater_path=str(updater_exe),
+                    local_app_data=str(local_app_data),
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_us_dicomizer_updater.py
+++ b/tests/test_us_dicomizer_updater.py
@@ -1,0 +1,68 @@
+import subprocess
+import unittest
+from unittest.mock import Mock
+
+from us_dicomizer_updater import (
+    build_installer_command,
+    relaunch_app,
+    run_installer,
+    wait_for_process_exit,
+)
+
+
+class UsDicomizerUpdaterTests(unittest.TestCase):
+    def test_build_installer_command_uses_silent_inno_setup_arguments(self):
+        command = build_installer_command(
+            installer_path=r"C:\Users\me\.anonymizer\updates\US-DICOMizer-Setup-v5.3.exe",
+            log_path=r"C:\Users\me\.anonymizer\updates\update.log",
+        )
+
+        self.assertEqual(command[0], r"C:\Users\me\.anonymizer\updates\US-DICOMizer-Setup-v5.3.exe")
+        self.assertIn("/VERYSILENT", command)
+        self.assertIn("/SUPPRESSMSGBOXES", command)
+        self.assertIn("/NORESTART", command)
+        self.assertIn(r'/LOG="C:\Users\me\.anonymizer\updates\update.log"', command)
+
+    def test_wait_for_process_exit_returns_true_when_process_is_already_gone(self):
+        result = wait_for_process_exit(
+            pid=1234,
+            timeout_seconds=0.1,
+            sleep_seconds=0,
+            process_exists=lambda pid: False,
+        )
+
+        self.assertTrue(result)
+
+    def test_wait_for_process_exit_times_out_while_process_stays_running(self):
+        result = wait_for_process_exit(
+            pid=1234,
+            timeout_seconds=0.01,
+            sleep_seconds=0,
+            process_exists=lambda pid: True,
+        )
+
+        self.assertFalse(result)
+
+    def test_run_installer_returns_completed_process_code(self):
+        runner = Mock(return_value=subprocess.CompletedProcess(args=["installer"], returncode=0))
+
+        return_code = run_installer(
+            installer_path=r"C:\setup.exe",
+            log_path=r"C:\update.log",
+            runner=runner,
+        )
+
+        self.assertEqual(return_code, 0)
+        runner.assert_called_once()
+        self.assertIn("/VERYSILENT", runner.call_args.args[0])
+
+    def test_relaunch_app_starts_app_without_waiting(self):
+        popen_factory = Mock()
+
+        relaunch_app(r"C:\Program Files\US-DICOMizer\US-DICOMizer.exe", popen_factory=popen_factory)
+
+        popen_factory.assert_called_once_with([r"C:\Program Files\US-DICOMizer\US-DICOMizer.exe"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_service.py
+++ b/update_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import PureWindowsPath
+from typing import Callable
+
+
+GITHUB_RELEASES_API = "https://api.github.com/repos/thrombusplus/US-DICOMizer/releases/latest"
+APP_NAME = "US-DICOMizer"
+UPDATER_EXE_NAME = "US-DICOMizer-Updater.exe"
+SETUP_ASSET_RE = re.compile(r"^US-DICOMizer-Setup-v\d+(?:\.\d+)*\.exe$", re.IGNORECASE)
+
+
+def parse_version(value: str) -> tuple[int, ...]:
+    text = str(value or "").strip()
+    if text.lower().startswith("v"):
+        text = text[1:]
+
+    match = re.match(r"(\d+(?:\.\d+)*)", text)
+    if not match:
+        return (0,)
+
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def is_newer_version(current_version: str, latest_tag: str) -> bool:
+    return parse_version(latest_tag) > parse_version(current_version)
+
+
+def select_setup_asset(release: dict) -> dict | None:
+    if not release or release.get("prerelease"):
+        return None
+
+    tag_name = release.get("tag_name", "")
+    expected_name = f"{APP_NAME}-Setup-{tag_name}.exe" if tag_name else ""
+    assets = release.get("assets", [])
+
+    for asset in assets:
+        if asset.get("name") == expected_name and asset.get("browser_download_url"):
+            return asset
+
+    for asset in assets:
+        name = asset.get("name", "")
+        if SETUP_ASSET_RE.match(name) and asset.get("browser_download_url"):
+            return asset
+
+    return None
+
+
+def get_updates_dir(app_directory: str) -> str:
+    return os.path.join(app_directory, "updates")
+
+
+def get_installer_download_path(app_directory: str, asset_name: str) -> str:
+    safe_name = os.path.basename(PureWindowsPath(asset_name).name)
+    return os.path.join(get_updates_dir(app_directory), safe_name)
+
+
+def get_installed_updater_path(app_executable_path: str | None = None) -> str:
+    app_path = app_executable_path or sys.executable
+    return os.path.join(os.path.dirname(os.path.abspath(app_path)), UPDATER_EXE_NAME)
+
+
+def expected_install_dir(local_app_data: str | None = None) -> str:
+    base = local_app_data or os.environ.get("LOCALAPPDATA", "")
+    return os.path.normpath(os.path.join(base, "Programs", APP_NAME))
+
+
+def path_is_within(child_path: str, parent_path: str) -> bool:
+    try:
+        child = os.path.normcase(os.path.abspath(os.path.normpath(child_path)))
+        parent = os.path.normcase(os.path.abspath(os.path.normpath(parent_path)))
+        return os.path.commonpath([child, parent]) == parent
+    except (OSError, ValueError):
+        return False
+
+
+def can_apply_installer_update(
+    *,
+    is_frozen: bool,
+    app_executable_path: str,
+    updater_path: str,
+    local_app_data: str | None = None,
+) -> bool:
+    return (
+        is_frozen
+        and os.path.isfile(updater_path)
+        and path_is_within(app_executable_path, expected_install_dir(local_app_data))
+    )
+
+
+def build_updater_command(
+    *,
+    updater_path: str,
+    installer_path: str,
+    app_executable_path: str,
+    app_pid: int,
+    log_path: str | None = None,
+) -> list[str]:
+    command = [
+        updater_path,
+        "--installer",
+        installer_path,
+        "--app-exe",
+        app_executable_path,
+        "--app-pid",
+        str(app_pid),
+    ]
+    if log_path:
+        command.extend(["--log", log_path])
+    return command
+
+
+def fetch_latest_release(
+    api_url: str = GITHUB_RELEASES_API,
+    *,
+    timeout: int = 10,
+    opener: Callable = urllib.request.urlopen,
+) -> dict:
+    request = urllib.request.Request(api_url, headers={"User-Agent": APP_NAME})
+    with opener(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def download_file(
+    url: str,
+    destination_path: str,
+    *,
+    timeout: int = 30,
+    opener: Callable = urllib.request.urlopen,
+    progress_callback: Callable[[int, int | None], None] | None = None,
+) -> str:
+    os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+    temp_path = f"{destination_path}.download"
+    request = urllib.request.Request(url, headers={"User-Agent": APP_NAME})
+
+    with opener(request, timeout=timeout) as response:
+        total = response.headers.get("Content-Length")
+        total_bytes = int(total) if total and total.isdigit() else None
+        downloaded = 0
+
+        with open(temp_path, "wb") as handle:
+            while True:
+                chunk = response.read(1024 * 256)
+                if not chunk:
+                    break
+                handle.write(chunk)
+                downloaded += len(chunk)
+                if progress_callback:
+                    progress_callback(downloaded, total_bytes)
+
+    os.replace(temp_path, destination_path)
+    return destination_path
+
+
+def remove_download(path: str):
+    try:
+        if path and os.path.exists(path):
+            os.remove(path)
+    except OSError:
+        pass
+
+
+def clear_old_downloads(updates_dir: str, keep_path: str):
+    if not os.path.isdir(updates_dir):
+        return
+
+    keep_path = os.path.abspath(keep_path)
+    for entry in os.listdir(updates_dir):
+        path = os.path.abspath(os.path.join(updates_dir, entry))
+        if path == keep_path or not entry.lower().endswith(".exe"):
+            continue
+        try:
+            os.remove(path)
+        except OSError:
+            pass

--- a/us_dicomizer_updater.py
+++ b/us_dicomizer_updater.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import subprocess
+import sys
+import time
+from typing import Callable
+
+
+STILL_ACTIVE = 259
+
+
+def build_installer_command(installer_path: str, log_path: str | None = None) -> list[str]:
+    command = [
+        installer_path,
+        "/VERYSILENT",
+        "/SUPPRESSMSGBOXES",
+        "/NORESTART",
+    ]
+    if log_path:
+        command.append(f'/LOG="{log_path}"')
+    return command
+
+
+def windows_process_exists(pid: int) -> bool:
+    if pid <= 0:
+        return False
+
+    kernel32 = ctypes.windll.kernel32
+    process_query_limited_information = 0x1000
+    handle = kernel32.OpenProcess(process_query_limited_information, False, int(pid))
+    if not handle:
+        return False
+
+    exit_code = ctypes.c_ulong()
+    try:
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def posix_process_exists(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def default_process_exists(pid: int) -> bool:
+    if os.name == "nt":
+        return windows_process_exists(pid)
+    return posix_process_exists(pid)
+
+
+def wait_for_process_exit(
+    pid: int,
+    *,
+    timeout_seconds: float = 120,
+    sleep_seconds: float = 0.5,
+    process_exists: Callable[[int], bool] = default_process_exists,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() <= deadline:
+        if not process_exists(pid):
+            return True
+        time.sleep(sleep_seconds)
+    return False
+
+
+def run_installer(
+    installer_path: str,
+    log_path: str | None = None,
+    *,
+    runner: Callable = subprocess.run,
+) -> int:
+    completed = runner(build_installer_command(installer_path, log_path))
+    return int(completed.returncode)
+
+
+def relaunch_app(app_executable_path: str, *, popen_factory: Callable = subprocess.Popen):
+    popen_factory([app_executable_path])
+
+
+def write_log(log_path: str | None, message: str):
+    if not log_path:
+        return
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    with open(log_path, "a", encoding="utf-8") as handle:
+        handle.write(f"{timestamp} {message}\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Install a downloaded US-DICOMizer update.")
+    parser.add_argument("--installer", required=True, help="Downloaded setup executable.")
+    parser.add_argument("--app-exe", required=True, help="Installed US-DICOMizer executable to relaunch.")
+    parser.add_argument("--app-pid", required=True, type=int, help="PID of the running app to wait for.")
+    parser.add_argument("--log", default="", help="Updater log path.")
+    parser.add_argument("--wait-timeout", default=120, type=float, help="Seconds to wait for the app to exit.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    log_path = args.log or os.path.join(os.path.dirname(args.installer), "update.log")
+
+    write_log(log_path, f"Waiting for app PID {args.app_pid} to exit.")
+    if not wait_for_process_exit(args.app_pid, timeout_seconds=args.wait_timeout):
+        write_log(log_path, "Timed out waiting for app to exit.")
+        return 2
+
+    if not os.path.isfile(args.installer):
+        write_log(log_path, f"Installer not found: {args.installer}")
+        return 3
+
+    write_log(log_path, f"Running installer: {args.installer}")
+    return_code = run_installer(args.installer, log_path)
+    write_log(log_path, f"Installer exited with code {return_code}.")
+    if return_code != 0:
+        return return_code
+
+    if os.path.isfile(args.app_exe):
+        write_log(log_path, f"Relaunching app: {args.app_exe}")
+        relaunch_app(args.app_exe)
+    else:
+        write_log(log_path, f"Installed app executable not found for relaunch: {args.app_exe}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Changed workflow name from "Build Windows Executable" to "Build Windows Installer".
- Added installation of Inno Setup via Chocolatey in the GitHub Actions workflow.
- Modified PyInstaller commands to build both the main application and an updater executable.
- Implemented Inno Setup script for creating a setup installer.
- Updated README with installation and update instructions.
- Refactored update service to handle application updates and version checks.
- Added unit tests for update service and updater functionality.
- Improved error handling and logging in the updater.